### PR TITLE
"_obsolete"-Fix(tm) for Umbraco 7.4-beta2

### DIFF
--- a/Src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
+++ b/Src/Our.Umbraco.Vorto/Web/UI/App_Plugins/Vorto/js/vorto.js
@@ -340,7 +340,7 @@ angular.module("umbraco.directives").directive('vortoProperty',
             restrict: "E",
             rep1ace: true,
             link: link,
-            templateUrl: 'views/directives/umb-editor.html',
+            templateUrl: 'views/components/property/umb-property-editor.html',
             scope: {
                 propertyEditorView: '=view',
                 config: '=',


### PR DESCRIPTION
The 7.4 directive cleanup (loosely U4-7143 and others) killed Vorto, this fix brings the editing back to life at least. Hope this does make sense :)